### PR TITLE
Paraphrase the dependencies in the sidebar

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -52,34 +52,54 @@
   vertical-align: middle;
 }
 
+.colored-underline {
+  position: relative;
+
+  &:after {
+    bottom: 3px;
+    content: '';
+    height: 2px;
+    left: 0;
+    position: absolute;
+    width: 100%;
+  }
+}
+
 // These colors are also defined in ForceDirectedGraph.jsx
 
-.colors-key .unknown{
+.colors-key .unknown,
+.colored-underline--unknown:after {
   background-color: #6f777b;
 }
 
-.colors-key .policy-area{
+.colors-key .policy-area,
+.colored-underline--policy-area:after {
   background-color: #2E358B;
 }
 
-.colors-key .resource-sharing{
+.colors-key .resource-sharing,
+.colored-underline--resource-sharing:after {
   background-color: #D53880;
 }
 
-.colors-key .shared-location{
+.colors-key .shared-location,
+.colored-underline--shared-location:after {
   background-color: #df3034;
 }
 
-.colors-key .technical-integration{
+.colors-key .technical-integration,
+.colored-underline--technical-integration:after {
   background-color: #FFBF47;
 }
 
-.colors-key .data-access{
+.colors-key .data-access,
+.colored-underline--data-access:after {
   background-color: #28A197;
 }
 
 .colors-key .responsible-for,
-.colors-key .organisation {
+.colors-key .organisation,
+.colored-underline--responsible-for:after {
   background-color: #F47738;
 }
 

--- a/src/components/ForceDirectedGraph.jsx
+++ b/src/components/ForceDirectedGraph.jsx
@@ -2,19 +2,9 @@ import * as d3 from 'd3'
 import React, { Component } from 'react'
 // import ReactFauxDOM from 'react-faux-dom'
 import PropTypes from '../propTypes'
-import {getRelatedNodes} from '../utils'
+import {getRelatedNodes, getColorFromDependencyType} from '../utils'
 
-// These colors are also defined in GraphKey.jsx
-const getColorFromDependencyType = {
-  'unknown': '#6f777b',
-  'policy_area': '#2E358B',
-  'resource_sharing': '#D53880',
-  'shared_location': '#df3034',
-  'technical_integration': '#FFBF47',
-  'data_access': '#28A197',
-  'responsible_for': '#F47738'
-}
-
+// These colors are also defined in Application.scss
 const getColorFromNodeType = {
   'organisation': '#F47738',
   'programme': '#912B88',

--- a/src/components/NodeMoreInfo.jsx
+++ b/src/components/NodeMoreInfo.jsx
@@ -1,12 +1,74 @@
 import React, { Component } from 'react'
 import PropTypes from '../propTypes'
-import {getRelatedNodes} from '../utils'
+import {getRelatedLinks} from '../utils'
+
+class Relationship extends Component {
+  static propTypes = {
+    link: PropTypes.shape({
+      source: PropTypes.string.isRequired,
+      target: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired
+    }).isRequired,
+    node: PropTypes.shape({
+      id: PropTypes.string.isRequired
+    }).isRequired
+  }
+
+  render () {
+    const {link, node} = this.props
+    let Phrase = () => <span>{node.id}</span>
+    const src = link.source
+    const tar = link.target
+    const linkStartsFromNode = src === node.id
+    switch (link.type) {
+      case 'unknown':
+        Phrase = (linkStartsFromNode)
+          ? () => <span>has an <span className='colored-underline colored-underline--unknown'>unknown</span> link to {tar}</span>
+          : () => <span>has an <span className='colored-underline colored-underline--unknown'>unknown</span> link from {src}</span>
+        break
+      case 'policy_area':
+        Phrase = (linkStartsFromNode)
+          ? () => <span>defines the <span className='colored-underline colored-underline--policy-area'>policy area</span> for {tar}</span>
+          : () => <span>operates on a <span className='colored-underline colored-underline--policy-area'>policy area</span> defined by {src}</span>
+        break
+      case 'resource_sharing':
+        Phrase = (linkStartsFromNode)
+          ? () => <span><span className='colored-underline colored-underline--resource-sharing'>shares resources</span> to {tar}</span>
+          : () => <span>gets <span className='colored-underline colored-underline--resource-sharing'>shared resources</span> from {src}</span>
+        break
+      case 'shared_location':
+        Phrase = (linkStartsFromNode)
+          ? () => <span><span className='colored-underline colored-underline--shared-location'>shares a location</span> to {tar}</span>
+          : () => <span><span className='colored-underline colored-underline--shared-location'>shares a location</span> from {src}</span>
+        break
+      case 'technical_integration':
+        Phrase = (linkStartsFromNode)
+          ? () => <span>offers <span className='colored-underline colored-underline--technical-integration'>technical integration</span> to {tar}</span>
+        : () => <span>receives <span className='colored-underline colored-underline--technical-integration'>technical integration</span> from {src}</span>
+        break
+      case 'data_access':
+        Phrase = (linkStartsFromNode)
+          ? () => <span>offers <span className='colored-underline colored-underline--data-access'>data access</span> to {tar}</span>
+          : () => <span><span className='colored-underline colored-underline--data-access'>accesses data</span> from {src}</span>
+        break
+      case 'responsible_for':
+        Phrase = (linkStartsFromNode)
+          ? () => <span>is <span className='colored-underline colored-underline--responsible-for'>responsible for</span> {tar}</span>
+          : () => <span>is <span className='colored-underline colored-underline--responsible-for'>dependent on</span> {src}</span>
+        break
+    }
+    return <div>
+      … <Phrase />
+    </div>
+  }
+}
 
 export default class NodeMoreInfo extends Component {
   static propTypes = {
     links: PropTypes.arrayOf(PropTypes.shape({
       source: PropTypes.string.isRequired,
-      target: PropTypes.string.isRequired
+      target: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired
     })).isRequired,
     node: PropTypes.shape({
       id: PropTypes.string.isRequired
@@ -15,18 +77,19 @@ export default class NodeMoreInfo extends Component {
 
   render () {
     const {links, node} = this.props
-    const relatedNodes = (node) ? getRelatedNodes(links, node) : []
+    const relatedLinks = (node) ? getRelatedLinks(links, node) : []
     return <div>
-      <p>Click on a node to find out more about it.</p>
-      <h2 className='heading-medium'>
-        Selected node: {(node) ? node.id : 'none' }
-      </h2>
+      <p>Click on a node to find out more about it. Click it again to unselect.</p>
       {(node)
         ? <div>
-          <p>Neighbouring nodes:</p>
+          <h2 className='heading-medium'>{node.id}</h2>
           <ul>
-            {relatedNodes.map((n, idx) =>
-              <li key={idx} style={{ listStyleType: 'disc' }}>{ (typeof n === 'object') ? n.id : n }</li>
+            {relatedLinks.map((link, idx) =>
+              <Relationship
+                key={idx}
+                link={link}
+                node={node}
+              />
             )}
           </ul>
         </div>

--- a/src/components/NodeMoreInfo.jsx
+++ b/src/components/NodeMoreInfo.jsx
@@ -28,8 +28,8 @@ class Relationship extends Component {
         break
       case 'policy_area':
         Phrase = (linkStartsFromNode)
-          ? () => <span>defines the <span className='colored-underline colored-underline--policy-area'>policy area</span> for {tar}</span>
-          : () => <span>operates on a <span className='colored-underline colored-underline--policy-area'>policy area</span> defined by {src}</span>
+          ? () => <span>sets the <span className='colored-underline colored-underline--policy-area'>policy area</span> for {tar}</span>
+          : () => <span>relies on a <span className='colored-underline colored-underline--policy-area'>policy area</span> set by {src}</span>
         break
       case 'resource_sharing':
         Phrase = (linkStartsFromNode)

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,22 @@
+import {curry} from 'lodash'
+
+const getLinkNodeId = (linkNode) => {
+  return (typeof linkNode === 'object')
+    ? linkNode.id
+    : linkNode
+}
+
+const isRelatedLink = curry((node, link) => {
+  const sourceIsRelated = getLinkNodeId(link.source) === node.id
+  const targetIsRelated = getLinkNodeId(link.target) === node.id
+  return sourceIsRelated || targetIsRelated
+})
+
+export function getRelatedLinks (links, node) {
+  return links.filter(isRelatedLink(node))
+}
+
 export function getRelatedNodes (links, node) {
-  const getLinkNodeId = ln => (typeof ln === 'object') ? ln.id : ln
-  const isRelatedLink = l => getLinkNodeId(l.source) === node.id || getLinkNodeId(l.target) === node.id
   const linkToRelatedNode = l => (getLinkNodeId(l.source) === node.id) ? l.target : l.source
-  return links
-    .filter(isRelatedLink)
-    .map(linkToRelatedNode)
+  return getRelatedLinks(links, node).map(linkToRelatedNode)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,16 @@
 import {curry} from 'lodash'
 
+// These colors are also defined in Application.scss
+export const getColorFromDependencyType = {
+  'unknown': '#6f777b',
+  'policy_area': '#2E358B',
+  'resource_sharing': '#D53880',
+  'shared_location': '#df3034',
+  'technical_integration': '#FFBF47',
+  'data_access': '#28A197',
+  'responsible_for': '#F47738'
+}
+
 const getLinkNodeId = (linkNode) => {
   return (typeof linkNode === 'object')
     ? linkNode.id


### PR DESCRIPTION
@sanjaypoyzer

Content is WIP and I did my best given that I have no idea what these things are; check the `<NodeMoreInfo />` component, they are roughly:

```
// … has an *unknown* link to X
// … has an *unknown* link from X

// … defines the *policy area* for X
// … operates on a *policy area* defined by X

// … *shares resources* to X
// … gets *shared resources* from X

// … *shares a location* to X
// … *shares a location* from X

// … offers *technical integration* to X
// … receives *technical integration* from X

// … offers *data access* to X
// … *accesses data* from X

// … is *responsible for* X
// … is *dependent on* X
```

![screen shot 2016-10-05 at 19 20 25](https://cloud.githubusercontent.com/assets/1650875/19126268/1d329d90-8b32-11e6-936a-274a92c0642a.png)
![screen shot 2016-10-05 at 19 21 42](https://cloud.githubusercontent.com/assets/1650875/19126276/25cbb982-8b32-11e6-8393-f05b20b8c5cc.png)
