### PR TITLE
Allow hovering and clicking on dependencies in sidebar

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -98,6 +98,7 @@
 }
 
 .dependency {
+  cursor: pointer;
   margin-left: 1.25em;
   position: relative;
   &:before {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -144,6 +144,7 @@
   .nodes circle {
     cursor: pointer;
     fill: #FFF;
+    transition: fill .3s ease;
 
     &.selected {
       fill: #555;

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -146,7 +146,7 @@ export default class App extends Component {
     }
   }
 
-  startClick(){
+  startClick () {
     this.setState({
       startClicked: true
     })
@@ -158,22 +158,20 @@ export default class App extends Component {
     computeAdjacencyLists(links)
     const nodes = this.getNodes()
     return <div>
-      {
-        this.state.startClicked ?
-          <GoogleSheetsApi
-            onReady={this.handleGoogleSheetsApiReady}
-          />
+      {this.state.startClicked
+        ? <GoogleSheetsApi
+          onReady={this.handleGoogleSheetsApiReady}
+        />
         : null
       }
       <div className='grid-row'>
         <div className='column-two-thirds'>
           <h1 className='heading-xlarge'>View government transformation</h1>
           <div className='graph-container'>
-            {this.state.startClicked ?
-              (loading) ?
-                <p>Loading...</p>
-                :
-                <div>
+            {this.state.startClicked
+              ? (loading)
+                ? <p>Loading...</p>
+                : <div>
                   <ForceDirectedGraph
                     height={480}
                     links={links}
@@ -183,11 +181,10 @@ export default class App extends Component {
                   />
                   <GraphKey />
                 </div>
-              :
-              <div>
+              : <div>
                 <p>This service shows you how transformation programmes in government are linked.</p>
                 <p>To get access, you need to login with a <code>@digital.cabinet-office.gov.uk</code> Google account.</p>
-                <a className="button button-start" href="#" role="button" onClick={this.startClick}>Start now</a>
+                <a className='button button-start' href='#' role='button' onClick={this.startClick}>Start now</a>
               </div>
             }
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -194,6 +194,7 @@ export default class App extends Component {
                     links={links}
                     onNodeClick={this.handleNodeClick}
                     nodes={nodes}
+                    selectedNode={selectedNode}
                     width={630}
                   />
                   <GraphKey />
@@ -215,6 +216,7 @@ export default class App extends Component {
                 node={selectedNode}
                 allNodes={nodes}
                 links={links}
+                onNodeClick={this.handleNodeClick}
                 onNodeMouseOver={this.handleNodeMouseOver}
                 onNodeMouseOut={this.handleNodeMouseOut}
               />

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -51,7 +51,7 @@ export default class App extends Component {
 
     const promiseDependencies = this.state.gapi.client.sheets.spreadsheets.values.get({
       spreadsheetId: SPREADSHEET_ID,
-      range: 'dependency!A2:F199'
+      range: 'dependency!A2:F221'
     }).then((response) => {
       const dependencies = response.result.values
       console.log('Fetched dependencies:', dependencies)
@@ -78,7 +78,7 @@ export default class App extends Component {
 
     const promiseServices = this.state.gapi.client.sheets.spreadsheets.values.get({
       spreadsheetId: SPREADSHEET_ID,
-      range: 'service!A2:G101'
+      range: 'service!A2:G120'
     }).then((response) => {
       const services = response.result.values
       console.log('Fetched services:', services)

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -28,6 +28,7 @@ export default class App extends Component {
     organisations: [],
     programmes: [],
     selectedNode: null,
+    hoveredNode: null,
     services: []
   }
 
@@ -38,6 +39,8 @@ export default class App extends Component {
     this.loadSpreadsheet = this.loadSpreadsheet.bind(this)
     this.handleNodeClick = this.handleNodeClick.bind(this)
     this.startClick = this.startClick.bind(this)
+    this.handleNodeMouseOver = this.handleNodeMouseOver.bind(this)
+    this.handleNodeMouseOut = this.handleNodeMouseOut.bind(this)
   }
 
   handleGoogleSheetsApiReady (gapi) {
@@ -153,8 +156,20 @@ export default class App extends Component {
     })
   }
 
+  handleNodeMouseOver (node) {
+    this.setState({
+      hoveredNode: node
+    })
+  }
+
+  handleNodeMouseOut (node) {
+    this.setState({
+      hoveredNode: null
+    })
+  }
+
   render () {
-    const {loading, selectedNode, startClicked} = this.state
+    const {loading, hoveredNode, selectedNode, startClicked} = this.state
     const links = this.getLinks()
     computeAdjacencyLists(links)
     const nodes = this.getNodes()
@@ -175,6 +190,7 @@ export default class App extends Component {
                 : <div>
                   <ForceDirectedGraph
                     height={480}
+                    hoveredNode={hoveredNode}
                     links={links}
                     onNodeClick={this.handleNodeClick}
                     nodes={nodes}
@@ -199,6 +215,8 @@ export default class App extends Component {
                 node={selectedNode}
                 allNodes={nodes}
                 links={links}
+                onNodeMouseOver={this.handleNodeMouseOver}
+                onNodeMouseOut={this.handleNodeMouseOut}
               />
             : null
           }

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -146,19 +146,20 @@ export default class App extends Component {
     }
   }
 
-  startClick () {
+  startClick (evt) {
+    evt.preventDefault()
     this.setState({
       startClicked: true
     })
   }
 
   render () {
-    const {loading, selectedNode} = this.state
+    const {loading, selectedNode, startClicked} = this.state
     const links = this.getLinks()
     computeAdjacencyLists(links)
     const nodes = this.getNodes()
     return <div>
-      {this.state.startClicked
+      {startClicked
         ? <GoogleSheetsApi
           onReady={this.handleGoogleSheetsApiReady}
         />
@@ -168,8 +169,8 @@ export default class App extends Component {
         <div className='column-two-thirds'>
           <h1 className='heading-xlarge'>View government transformation</h1>
           <div className='graph-container'>
-            {this.state.startClicked
-              ? (loading)
+            {startClicked
+              ? loading
                 ? <p>Loading...</p>
                 : <div>
                   <ForceDirectedGraph
@@ -191,13 +192,15 @@ export default class App extends Component {
           </div>
         </div>
         <div className='column-one-third' style={{paddingTop: '140px'}}>
-          {(loading)
-            ? null
-            : <NodeMoreInfo
-              node={selectedNode}
-              allNodes={nodes}
-              links={links}
-            />
+          {startClicked
+            ? loading
+              ? null
+              : <NodeMoreInfo
+                node={selectedNode}
+                allNodes={nodes}
+                links={links}
+              />
+            : null
           }
         </div>
       </div>

--- a/src/components/ForceDirectedGraph.jsx
+++ b/src/components/ForceDirectedGraph.jsx
@@ -91,6 +91,8 @@ export default class ForceDirectedGraph extends Component {
           this.props.onNodeClick(d)
           handleNodeClick(d)
         })
+        .on('mouseover', onMouseover)
+        .on('mouseout', onMouseout)
 
     const label = svg.append('g')
         .attr('class', 'labels')
@@ -161,9 +163,21 @@ export default class ForceDirectedGraph extends Component {
         previousNode = null
       } else {
         const nodes = getRelatedNodes(data.links, d).concat([d])
-        nodes.forEach(node => d3.selectAll(`[data-node-id="${node.id}"]`).classed('selected', true))
+        d3.select(`text[data-node-id="${d.id}"]`).classed('selected', true)
+        nodes.forEach(node => d3.selectAll(`circle[data-node-id="${node.id}"]`).classed('selected', true))
         previousNodes = nodes
         previousNode = d
+      }
+    }
+
+    function onMouseover (d) {
+      d3.select(`text[data-node-id="${d.id}"]`).classed('selected', true)
+    }
+
+    function onMouseout (d) {
+      const isClicked = previousNode === d
+      if (!isClicked) {
+        d3.select(`text[data-node-id="${d.id}"]`).classed('selected', false)
       }
     }
   }

--- a/src/components/ForceDirectedGraph.jsx
+++ b/src/components/ForceDirectedGraph.jsx
@@ -30,6 +30,9 @@ export default class ForceDirectedGraph extends Component {
     nodes: PropTypes.arrayOf(PropTypes.shape({
       id: PropTypes.string.isRequired
     })).isRequired,
+    selectedNode: PropTypes.shape({
+      id: PropTypes.string.isRequired
+    }),
     width: PropTypes.number
   }
 
@@ -54,6 +57,12 @@ export default class ForceDirectedGraph extends Component {
     }
     if (newHoveredNode) {
       d3.select(`text[data-node-id="${newHoveredNode.id}"]`).classed('selected', true)
+    }
+
+    const prevSelectedNode = prevState.selectedNode
+    const newSelectedNode = this.props.selectedNode
+    if (prevSelectedNode !== newSelectedNode) {
+      this.handleNodeClick(newSelectedNode)
     }
   }
 
@@ -121,7 +130,6 @@ export default class ForceDirectedGraph extends Component {
           .on('end', dragended))
         .on('click', (d) => {
           this.props.onNodeClick(d)
-          this.handleNodeClick(d)
         })
         .on('mouseover', this.onMouseover)
         .on('mouseout', this.onMouseout)
@@ -202,18 +210,18 @@ export default class ForceDirectedGraph extends Component {
     let {previousNode, previousNodes} = this.state
     previousNodes.forEach(node => d3.selectAll(`[data-node-id="${node.id}"]`).classed('selected', false))
     const alreadyToggled = previousNode === d
-    if (alreadyToggled) {
-      this.setState({
-        previousNodes: [],
-        previousNode: null
-      })
-    } else {
+    if (d) {
       const nodes = getRelatedNodes(data.links, d).concat([d])
       d3.select(`text[data-node-id="${d.id}"]`).classed('selected', true)
       nodes.forEach(node => d3.selectAll(`circle[data-node-id="${node.id}"]`).classed('selected', true))
       this.setState({
         previousNodes: nodes,
         previousNode: d
+      })
+    } else if (alreadyToggled) {
+      this.setState({
+        previousNodes: [],
+        previousNode: null
       })
     }
   }

--- a/src/components/GoogleSheetsApi.jsx
+++ b/src/components/GoogleSheetsApi.jsx
@@ -40,7 +40,6 @@ export default class GoogleSheetsApi extends Component {
   }
 
   loadSheetsApi () {
-    this.setState({ googleAuthError: false })
     gapi.auth.authorize({
       'client_id': CLIENT_ID,
       'scope': SCOPES,

--- a/src/components/NodeMoreInfo.jsx
+++ b/src/components/NodeMoreInfo.jsx
@@ -8,7 +8,24 @@ class PrettyNodeList extends Component {
       id: PropTypes.string.isRequired,
       type: PropTypes.oneOf(['organisation', 'programme', 'service']).isRequired
     })).isRequired,
-    nodes: PropTypes.arrayOf(PropTypes.string).isRequired
+    nodes: PropTypes.arrayOf(PropTypes.string).isRequired,
+    onNodeMouseOver: PropTypes.func.isRequired,
+    onNodeMouseOut: PropTypes.func.isRequired
+  }
+
+  constructor (props) {
+    super(props)
+
+    this.onItemMouseOver = this.onItemMouseOver.bind(this)
+    this.onItemMouseOut = this.onItemMouseOut.bind(this)
+  }
+
+  onItemMouseOver (node) {
+    this.props.onNodeMouseOver(node)
+  }
+
+  onItemMouseOut (node) {
+    this.props.onNodeMouseOut(node)
   }
 
   render () {
@@ -20,6 +37,8 @@ class PrettyNodeList extends Component {
         return <li
           className={`dependency dependency--${node.type}`}
           key={idx}
+          onMouseOver={() => this.onItemMouseOver(node)}
+          onMouseOut={() => this.onItemMouseOut(node)}
         >{node.id}</li>
       })}
     </ul>
@@ -33,7 +52,9 @@ class Relationship extends Component {
       type: PropTypes.oneOf(['organisation', 'programme', 'service']).isRequired
     })).isRequired,
     nodes: PropTypes.arrayOf(PropTypes.string).isRequired,
-    type: PropTypes.string.isRequired
+    type: PropTypes.string.isRequired,
+    onNodeMouseOver: PropTypes.func.isRequired,
+    onNodeMouseOut: PropTypes.func.isRequired
   }
 
   render () {
@@ -76,6 +97,8 @@ class Relationship extends Component {
       <PrettyNodeList
         allNodes={allNodes}
         nodes={nodes}
+        onNodeMouseOver={this.props.onNodeMouseOver}
+        onNodeMouseOut={this.props.onNodeMouseOut}
       />
     </div>
   }
@@ -94,7 +117,9 @@ export default class NodeMoreInfo extends Component {
     })).isRequired,
     node: PropTypes.shape({
       id: PropTypes.string.isRequired
-    })
+    }),
+    onNodeMouseOver: PropTypes.func.isRequired,
+    onNodeMouseOut: PropTypes.func.isRequired
   }
 
   render () {
@@ -112,6 +137,8 @@ export default class NodeMoreInfo extends Component {
                 allNodes={allNodes}
                 key={idx}
                 nodes={groupedRelatedLinks[type]}
+                onNodeMouseOver={this.props.onNodeMouseOver}
+                onNodeMouseOut={this.props.onNodeMouseOut}
                 type={type}
               />
             )}

--- a/src/components/NodeMoreInfo.jsx
+++ b/src/components/NodeMoreInfo.jsx
@@ -9,6 +9,7 @@ class PrettyNodeList extends Component {
       type: PropTypes.oneOf(['organisation', 'programme', 'service']).isRequired
     })).isRequired,
     nodes: PropTypes.arrayOf(PropTypes.string).isRequired,
+    onNodeClick: PropTypes.func.isRequired,
     onNodeMouseOver: PropTypes.func.isRequired,
     onNodeMouseOut: PropTypes.func.isRequired
   }
@@ -16,8 +17,13 @@ class PrettyNodeList extends Component {
   constructor (props) {
     super(props)
 
+    this.onItemClick = this.onItemClick.bind(this)
     this.onItemMouseOver = this.onItemMouseOver.bind(this)
     this.onItemMouseOut = this.onItemMouseOut.bind(this)
+  }
+
+  onItemClick (node) {
+    this.props.onNodeClick(node)
   }
 
   onItemMouseOver (node) {
@@ -37,6 +43,7 @@ class PrettyNodeList extends Component {
         return <li
           className={`dependency dependency--${node.type}`}
           key={idx}
+          onClick={() => this.onItemClick(node)}
           onMouseOver={() => this.onItemMouseOver(node)}
           onMouseOut={() => this.onItemMouseOut(node)}
         >{node.id}</li>
@@ -53,6 +60,7 @@ class Relationship extends Component {
     })).isRequired,
     nodes: PropTypes.arrayOf(PropTypes.string).isRequired,
     type: PropTypes.string.isRequired,
+    onNodeClick: PropTypes.func.isRequired,
     onNodeMouseOver: PropTypes.func.isRequired,
     onNodeMouseOut: PropTypes.func.isRequired
   }
@@ -97,6 +105,7 @@ class Relationship extends Component {
       <PrettyNodeList
         allNodes={allNodes}
         nodes={nodes}
+        onNodeClick={this.props.onNodeClick}
         onNodeMouseOver={this.props.onNodeMouseOver}
         onNodeMouseOut={this.props.onNodeMouseOut}
       />
@@ -118,8 +127,12 @@ export default class NodeMoreInfo extends Component {
     node: PropTypes.shape({
       id: PropTypes.string.isRequired
     }),
+    onNodeClick: PropTypes.func.isRequired,
     onNodeMouseOver: PropTypes.func.isRequired,
-    onNodeMouseOut: PropTypes.func.isRequired
+    onNodeMouseOut: PropTypes.func.isRequired,
+    selectedNode: PropTypes.shape({
+      id: PropTypes.string.isRequired
+    })
   }
 
   render () {
@@ -137,6 +150,7 @@ export default class NodeMoreInfo extends Component {
                 allNodes={allNodes}
                 key={idx}
                 nodes={groupedRelatedLinks[type]}
+                onNodeClick={this.props.onNodeClick}
                 onNodeMouseOver={this.props.onNodeMouseOver}
                 onNodeMouseOut={this.props.onNodeMouseOut}
                 type={type}


### PR DESCRIPTION
@sanjaypoyzer
- Don't display all the labels when clicking on a node
- Hovering will highlight their label in the graph
- Clicking will seleect them
- Pull in more rows from the spreadsheet

![screen shot 2016-10-06 at 14 16 54](https://cloud.githubusercontent.com/assets/1650875/19153766/b80a040a-8bcf-11e6-8361-5f2f63573e24.png)
